### PR TITLE
Th 64/18/view all mentoring sessions

### DIFF
--- a/src/app/services/session/apiSessionSlice.ts
+++ b/src/app/services/session/apiSessionSlice.ts
@@ -1,0 +1,18 @@
+import { apiSlice } from '../apiSlice'
+import { SessionResponse } from './types'
+import { defaultOnQueryStarted as onQueryStarted } from '../utils'
+
+const apiSessionSlice = apiSlice.injectEndpoints({
+  endpoints: (build) => ({
+    getMenteeSessions: build.query<SessionResponse, string | number>({
+      query: (menteeId) => ({
+        url: `/session/${menteeId}`,
+        method: 'GET',
+      }),
+      onQueryStarted,
+    }),
+  }),
+  overrideExisting: false,
+})
+
+export const { useLazyGetMenteeSessionsQuery } = apiSessionSlice

--- a/src/app/services/session/apiSessionSlice.ts
+++ b/src/app/services/session/apiSessionSlice.ts
@@ -4,9 +4,18 @@ import { defaultOnQueryStarted as onQueryStarted } from '../utils'
 
 const apiSessionSlice = apiSlice.injectEndpoints({
   endpoints: (build) => ({
+    // for Mentor
     getMenteeSessions: build.query<SessionResponse, string | number>({
       query: (menteeId) => ({
         url: `/session/${menteeId}`,
+        method: 'GET',
+      }),
+      onQueryStarted,
+    }),
+    // for Mentee
+    getSessions: build.query<SessionResponse, null>({
+      query: () => ({
+        url: '/session',
         method: 'GET',
       }),
       onQueryStarted,
@@ -15,4 +24,4 @@ const apiSessionSlice = apiSlice.injectEndpoints({
   overrideExisting: false,
 })
 
-export const { useLazyGetMenteeSessionsQuery } = apiSessionSlice
+export const { useLazyGetMenteeSessionsQuery, useLazyGetSessionsQuery } = apiSessionSlice

--- a/src/app/services/session/types.ts
+++ b/src/app/services/session/types.ts
@@ -1,0 +1,4 @@
+export interface SessionResponse {
+  // TODO: HELP DO THIS LANCE
+
+}

--- a/src/app/services/session/types.ts
+++ b/src/app/services/session/types.ts
@@ -1,4 +1,18 @@
+export interface Session {
+  sessionId: number
+  status: string
+  fromDateTime: string
+  toDateTime: string
+  sessionType: string
+  location: string
+  notes: string
+  mentoringJourneyId: number
+  title: string
+  description: string
+  reason: string
+}
+
 export interface SessionResponse {
   // TODO: HELP DO THIS LANCE
-
+  sessions: Session[]
 }

--- a/src/app/services/session/types.ts
+++ b/src/app/services/session/types.ts
@@ -12,7 +12,4 @@ export interface Session {
   reason: string
 }
 
-export interface SessionResponse {
-  // TODO: HELP DO THIS LANCE
-  sessions: Session[]
-}
+export type SessionResponse = Session[]

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -36,6 +36,15 @@ function Sessions() {
   }, [menteeId, getMenteeSessions])
 
   const sessions = data ?? []
+  const todayDate = new Date()
+  const upcomingSessions = sessions.filter(({ status, fromDateTime }) => {
+    const sessionDate = new Date(fromDateTime)
+    return status === 'confirmed' && sessionDate > todayDate
+  })
+  const pastSessions = sessions.filter(({ status, fromDateTime }) => {
+    const sessionDate = new Date(fromDateTime)
+    return status === 'confirmed' && sessionDate <= todayDate
+  })
   const pendingSessions = sessions.filter(({ status }) => status === 'pending_confirmation' || status === 'pending_rejected')
 
   return (
@@ -66,10 +75,10 @@ function Sessions() {
         </Stack>
         <TabPanels>
           <TabPanel px="0" pt="0">
-            <UpcomingAndPastSessionsTable />
+            <UpcomingAndPastSessionsTable data={upcomingSessions} />
           </TabPanel>
           <TabPanel px="0" pt="0">
-            <UpcomingAndPastSessionsTable />
+            <UpcomingAndPastSessionsTable data={pastSessions} />
           </TabPanel>
           <TabPanel px="0" pt="0">
             <PendingSessionsTable data={pendingSessions} />

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -53,13 +53,13 @@ function Sessions() {
   const todayDate = new Date()
   const upcomingSessions = sessions.filter(({ status, fromDateTime }) => {
     const sessionDate = new Date(fromDateTime)
-    return status === 'confirmed' && sessionDate > todayDate
+    return status === 'Confirmed' && sessionDate > todayDate
   })
   const pastSessions = sessions.filter(({ status, fromDateTime }) => {
     const sessionDate = new Date(fromDateTime)
-    return status === 'confirmed' && sessionDate <= todayDate
+    return status === 'Confirmed' && sessionDate <= todayDate
   })
-  const pendingSessions = sessions.filter(({ status }) => status === 'pending_confirmation' || status === 'pending_rejected')
+  const pendingSessions = sessions.filter(({ status }) => status === 'Pending' || status === 'Rejected')
   const calendarDates = sessions.map((session) => session.fromDateTime)
 
   return (

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -44,12 +44,12 @@ function Sessions() {
 
   const sessions = data ?? []
   const todayDate = new Date()
-  const upcomingSessions = sessions.filter(({ status, fromDateTime }) => {
-    const sessionDate = new Date(fromDateTime)
+  const upcomingSessions = sessions.filter(({ status, toDateTime }) => {
+    const sessionDate = new Date(toDateTime)
     return status === 'Confirmed' && sessionDate > todayDate
   })
-  const pastSessions = sessions.filter(({ status, fromDateTime }) => {
-    const sessionDate = new Date(fromDateTime)
+  const pastSessions = sessions.filter(({ status, toDateTime }) => {
+    const sessionDate = new Date(toDateTime)
     return status === 'Confirmed' && sessionDate <= todayDate
   })
   const pendingSessions = sessions.filter(({ status }) => status === 'Pending' || status === 'Rejected')

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -16,13 +16,13 @@ function Sessions() {
   const { role } = useAppSelector(getAuth)
   const [menteeId, setMenteeId] = useState('')
   const { options: assignedMenteeOptions } = useAssignedMenteesOptions()
-  const [getMenteeSessions, menteeResult] = useLazyGetMenteeSessionsQuery()
+  const [getSessionsByMenteeId, sessionByMenteeIdResult] = useLazyGetMenteeSessionsQuery()
   const [getSessions, sessionResult] = useLazyGetSessionsQuery()
   const handleMenteeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const selectedMenteeId = e.target.value
     setMenteeId(selectedMenteeId)
   }
-  const { data } = role === 'Mentor' ? menteeResult : sessionResult
+  const { data } = role === 'Mentor' ? sessionByMenteeIdResult : sessionResult
 
   // Set mentee ID after assigned mentee have been fetched
   useEffect(() => {
@@ -34,13 +34,17 @@ function Sessions() {
 
   // Get mentee sessions when mentee ID is set
   useEffect(() => {
-    if (role === 'Mentor') {
-      if (!menteeId) return
-      getMenteeSessions(menteeId)
-    } else {
+    if (role === 'Mentor' && !!menteeId) {
+      getSessionsByMenteeId(menteeId)
+    }
+  }, [getSessionsByMenteeId, menteeId, role])
+
+  // Get mentee's session if user is mentee
+  useEffect(() => {
+    if (role === 'Mentee') {
       getSessions(null)
     }
-  }, [menteeId, getMenteeSessions, getSessions, role])
+  }, [getSessions, role])
 
   const sessions = data ?? []
   const todayDate = new Date()
@@ -52,8 +56,8 @@ function Sessions() {
     const sessionDate = new Date(toDateTime)
     return status === 'Confirmed' && sessionDate <= todayDate
   })
-  const pendingSessions = sessions.filter(({ status }) => status === 'Pending' || status === 'Rejected')
-  const calendarDates = sessions.map((session) => session.fromDateTime)
+  const pendingSessions = sessions.filter(({ status }) => status !== 'Confirmed')
+  const datesWithSessions = sessions.map((session) => session.fromDateTime)
 
   return (
     <Container minHeight="calc(100vh - 32px)">
@@ -71,7 +75,7 @@ function Sessions() {
       <Hide above="sm">
         <Text fontWeight="400" fontSize="md" color="secondary.500"> Browse upcoming, past and pending sessions all in one place!</Text>
       </Hide>
-      <Calendar datesWithSessions={calendarDates} />
+      <Calendar datesWithSessions={datesWithSessions} />
       <Tabs variant="solid-rounded" colorScheme="red">
         <Stack justify="space-between" mb="4" direction={['column-reverse', 'column-reverse', 'row']}>
           <TabList gap={['1', '1', '6']} w="max-content" overflowX="auto">

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -4,7 +4,7 @@ import {
 import { ChangeEvent, useEffect, useState } from 'react'
 import { getAuth } from '../../app/redux/selectors'
 import Container from '../../components/Container'
-import { useAppDispatch, useAppSelector } from '../../hooks'
+import { useAppSelector } from '../../hooks'
 import { ControlledSelect } from '../../components'
 import useAssignedMenteesOptions from '../../hooks/useAssignedMenteesOptions'
 import Calendar from './Calendar/Calendar'
@@ -13,20 +13,14 @@ import PendingSessionsTable from './SessionsTable/PendingSessionsTable'
 import { useLazyGetMenteeSessionsQuery, useLazyGetSessionsQuery } from '../../app/services/session/apiSessionSlice'
 
 function Sessions() {
-  const dispatch = useAppDispatch()
   const { role } = useAppSelector(getAuth)
   const [menteeId, setMenteeId] = useState('')
-  const [menteeName, setMenteeName] = useState('')
   const { options: assignedMenteeOptions } = useAssignedMenteesOptions()
   const [getMenteeSessions, menteeResult] = useLazyGetMenteeSessionsQuery()
   const [getSessions, sessionResult] = useLazyGetSessionsQuery()
   const handleMenteeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const selectedMenteeId = e.target.value
     setMenteeId(selectedMenteeId)
-    const selectedMentee = assignedMenteeOptions.find((option) => option.value === selectedMenteeId)
-    if (selectedMentee) {
-      setMenteeName(selectedMentee.children)
-    }
   }
   const { data } = role === 'Mentor' ? menteeResult : sessionResult
 
@@ -35,9 +29,8 @@ function Sessions() {
     if (assignedMenteeOptions.length > 0 && !menteeId) {
       const firstMenteeId = assignedMenteeOptions[0].value
       setMenteeId(firstMenteeId)
-      setMenteeName(menteeName)
     }
-  }, [assignedMenteeOptions, dispatch, menteeId, menteeName])
+  }, [assignedMenteeOptions, menteeId])
 
   // Get mentee sessions when mentee ID is set
   useEffect(() => {

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -35,6 +35,9 @@ function Sessions() {
     getMenteeSessions(menteeId)
   }, [menteeId, getMenteeSessions])
 
+  const sessions = data ?? []
+  const pendingSessions = sessions.filter(({ status }) => status === 'pending_confirmation' || status === 'pending_rejected')
+
   return (
     <Container minHeight="calc(100vh - 32px)">
       <Flex justify="space-between" mb="4" gap="2">
@@ -69,7 +72,7 @@ function Sessions() {
             <UpcomingAndPastSessionsTable />
           </TabPanel>
           <TabPanel px="0" pt="0">
-            <PendingSessionsTable />
+            <PendingSessionsTable data={pendingSessions} />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -46,7 +46,7 @@ function Sessions() {
     return status === 'confirmed' && sessionDate <= todayDate
   })
   const pendingSessions = sessions.filter(({ status }) => status === 'pending_confirmation' || status === 'pending_rejected')
-
+  const calendarDates = sessions.map((session) => session.fromDateTime)
   return (
     <Container minHeight="calc(100vh - 32px)">
       <Flex justify="space-between" mb="4" gap="2">
@@ -63,7 +63,7 @@ function Sessions() {
       <Hide above="sm">
         <Text fontWeight="400" fontSize="md" color="secondary.500"> Browse upcoming, past and pending sessions all in one place!</Text>
       </Hide>
-      <Calendar datesWithSessions={[]} />
+      <Calendar datesWithSessions={calendarDates} />
       <Tabs variant="solid-rounded" colorScheme="red">
         <Stack justify="space-between" mb="4" direction={['column-reverse', 'column-reverse', 'row']}>
           <TabList gap={['1', '1', '6']} w="max-content" overflowX="auto">

--- a/src/features/Sessions/Sessions.tsx
+++ b/src/features/Sessions/Sessions.tsx
@@ -10,20 +10,30 @@ import useAssignedMenteesOptions from '../../hooks/useAssignedMenteesOptions'
 import Calendar from './Calendar/Calendar'
 import UpcomingAndPastSessionsTable from './SessionsTable/UpcomingAndPastSessionsTable'
 import PendingSessionsTable from './SessionsTable/PendingSessionsTable'
+import { useLazyGetMenteeSessionsQuery } from '../../app/services/session/apiSessionSlice'
 
 function Sessions() {
   const dispatch = useAppDispatch()
   const { role } = useAppSelector(getAuth)
   const [menteeId, setMenteeId] = useState('')
   const { options: assignedMenteeOptions } = useAssignedMenteesOptions()
+  const [getMenteeSessions, result] = useLazyGetMenteeSessionsQuery()
   const handleMenteeChange = (e: ChangeEvent<HTMLSelectElement>) => setMenteeId(e.target.value)
+  const { data } = result
 
+  // Set mentee ID after assigned mentee have been fetched
   useEffect(() => {
     if (assignedMenteeOptions.length > 0 && !menteeId) {
       const firstMenteeId = assignedMenteeOptions[0].value
       setMenteeId(firstMenteeId)
     }
   }, [assignedMenteeOptions, dispatch, menteeId])
+
+  // Get mentee sessions when mentee ID is set
+  useEffect(() => {
+    if (!menteeId) return
+    getMenteeSessions(menteeId)
+  }, [menteeId, getMenteeSessions])
 
   return (
     <Container minHeight="calc(100vh - 32px)">

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -57,7 +57,7 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
                   {title}
                 </Td>
                 <Td>
-                  {sessionType}
+                  {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
                 </Td>
                 <Td>
                   <Badge

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -116,21 +116,30 @@ function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
                   {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
                 </Td>
                 <Td>
-                  {/* Lance: to check with kc how we want to do this */}
-                  <HStack display="flex" justifyContent="start">
-                    <Button colorScheme="red">
-                      <HStack>
-                        <Icon name="done" color="white" />
-                        <Text> Accept</Text>
-                      </HStack>
-                    </Button>
-                    <Button colorScheme="red" variant="outline">
-                      <HStack>
-                        <Icon name="close" color="primary.700" />
-                        <Text> Decline</Text>
-                      </HStack>
-                    </Button>
-                  </HStack>
+                  {status === 'Pending' && (
+                    <HStack display="flex" justifyContent="start">
+                      <Button colorScheme="red" size="sm">
+                        <HStack>
+                          <Icon name="done" color="white" />
+                          <Text> Accept</Text>
+                        </HStack>
+                      </Button>
+                      <Button colorScheme="red" variant="outline" size="sm">
+                        <HStack>
+                          <Icon name="close" color="primary.700" />
+                          <Text> Decline</Text>
+                        </HStack>
+                      </Button>
+                    </HStack>
+                  )}
+                  {status === 'Rejected' && (
+                    <Badge
+                      colorScheme="yellow"
+                    >
+                      Awaiting Confirmation
+                    </Badge>
+                  )}
+
                 </Td>
               </Tr>
             )

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -16,7 +16,7 @@ function PendingSessionsTable(props: PendingSessionsTableProps) {
   return role === 'Mentor' ? (
     <PendingSessionsTableMentor data={data} />
   ) : (
-    <PendingSessionsTableMentee data={data} />
+    <PendingSessionsTableMentee />
   )
 }
 
@@ -79,9 +79,7 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
   )
 }
 
-function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
-  const { data } = props
-
+function PendingSessionsTableMentee() {
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">
@@ -97,7 +95,7 @@ function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
         <Tbody>
           <Tr>
             <Td>
-              <Flex gap="2" align="center" />
+              Hello
             </Td>
             <Td />
             <Td />

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -3,16 +3,25 @@ import {
 } from '@chakra-ui/react'
 import { useAppSelector } from '../../../hooks'
 import { getAuth } from '../../../app/redux/selectors'
+import { SessionResponse } from '../../../app/services/session/types'
 
-function PendingSessionsTable() {
+interface PendingSessionsTableProps {
+  data: SessionResponse
+}
+
+function PendingSessionsTable(props: PendingSessionsTableProps) {
+  const { data } = props
   const { role } = useAppSelector(getAuth)
-  const TableComponent = role === 'Mentor' ? PendingSessionsTableMentor : PendingSessionsTableMentee
-  return (
-    <TableComponent />
+  return role === 'Mentor' ? (
+    <PendingSessionsTableMentor data={data} />
+  ) : (
+    <PendingSessionsTableMentee data={data} />
   )
 }
 
-function PendingSessionsTableMentor() {
+function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
+  const { data } = props
+
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">
@@ -41,7 +50,9 @@ function PendingSessionsTableMentor() {
   )
 }
 
-function PendingSessionsTableMentee() {
+function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
+  const { data } = props
+
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -16,7 +16,7 @@ function PendingSessionsTable(props: PendingSessionsTableProps) {
   return role === 'Mentor' ? (
     <PendingSessionsTableMentor data={data} />
   ) : (
-    <PendingSessionsTableMentee />
+    <PendingSessionsTableMentee data={data} />
   )
 }
 
@@ -79,7 +79,8 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
   )
 }
 
-function PendingSessionsTableMentee() {
+function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
+  const { data } = props
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -1,5 +1,5 @@
 import {
-  Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr, Badge, Text, VStack,
+  Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr, Badge, Text, VStack, Button, HStack,
 } from '@chakra-ui/react'
 import { useAppSelector } from '../../../hooks'
 import { getAuth } from '../../../app/redux/selectors'
@@ -32,13 +32,13 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
             <Th>Title</Th>
             <Th> Type </Th>
             <Th> Status </Th>
-            <Th> Reason </Th>
+            <Th> <Flex justifyContent="center">Reason </Flex></Th>
           </Tr>
         </Thead>
         <Tbody>
           {data.map((session) => {
             const {
-              fromDateTime, title, sessionType, status, reason,
+              fromDateTime, title, sessionType, status,
             } = session
 
             const dateObject = new Date(fromDateTime)
@@ -61,14 +61,13 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
                 </Td>
                 <Td>
                   <Badge
-                    colorScheme={status === 'pending_confirmation' ? 'yellow' : 'red'}
+                    colorScheme={status === 'Pending' ? 'yellow' : 'red'}
                   >
-                    {status === 'pending_confirmation' ? 'Awaiting Confirmation' : 'Rejected'}
+                    {status === 'Pending' ? 'Awaiting Confirmation' : 'Rejected'}
                   </Badge>
                 </Td>
                 <Td>
-                  {reason && <Icon name="info" />}
-
+                  {status === 'Rejected' && <Flex justifyContent="center"><Icon name="info" /></Flex>}
                 </Td>
               </Tr>
             )
@@ -89,21 +88,53 @@ function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
             <Th>Date & Time</Th>
             <Th>Title</Th>
             <Th> Type </Th>
-            <Th> Status </Th>
-            <Th />
+            <Th><Flex display="flex" justifyContent="start">Status</Flex>  </Th>
           </Tr>
         </Thead>
         <Tbody>
-          <Tr>
-            <Td>
-              Hello
-            </Td>
-            <Td />
-            <Td />
-            <Td>
-              <Flex justify="end" />
-            </Td>
-          </Tr>
+          {data.map((session) => {
+            const {
+              fromDateTime, title, sessionType, status,
+            } = session
+
+            const dateObject = new Date(fromDateTime)
+            const date = dateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+            const time = dateObject.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+
+            return (
+              <Tr>
+                <Td>
+                  <VStack alignItems="start">
+                    <Text color="primary.800"> {date}</Text>
+                    <Text> {time}</Text>
+                  </VStack>
+                </Td>
+                <Td>
+                  {title}
+                </Td>
+                <Td>
+                  {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
+                </Td>
+                <Td>
+                  {/* Lance: to check with kc how we want to do this */}
+                  <HStack display="flex" justifyContent="start">
+                    <Button colorScheme="red">
+                      <HStack>
+                        <Icon name="done" color="white" />
+                        <Text> Accept</Text>
+                      </HStack>
+                    </Button>
+                    <Button colorScheme="red" variant="outline">
+                      <HStack>
+                        <Icon name="close" color="primary.700" />
+                        <Text> Decline</Text>
+                      </HStack>
+                    </Button>
+                  </HStack>
+                </Td>
+              </Tr>
+            )
+          })}
         </Tbody>
       </Table>
     </TableContainer>

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -1,9 +1,10 @@
 import {
-  Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr,
+  Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr, Badge, Text, VStack,
 } from '@chakra-ui/react'
 import { useAppSelector } from '../../../hooks'
 import { getAuth } from '../../../app/redux/selectors'
 import { SessionResponse } from '../../../app/services/session/types'
+import { Icon } from '../../../components'
 
 interface PendingSessionsTableProps {
   data: SessionResponse
@@ -35,15 +36,43 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
           </Tr>
         </Thead>
         <Tbody>
-          <Tr>
-            <Td>
-              <Flex gap="2" align="center" />
-            </Td>
-            <Td />
-            <Td />
-            <Td />
-            <Td />
-          </Tr>
+          {data.map((session) => {
+            const {
+              fromDateTime, title, sessionType, status, reason,
+            } = session
+
+            const dateObject = new Date(fromDateTime)
+            const date = dateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+            const time = dateObject.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+
+            return (
+              <Tr>
+                <Td>
+                  <VStack alignItems="start">
+                    <Text color="primary.800"> {date}</Text>
+                    <Text> {time}</Text>
+                  </VStack>
+                </Td>
+                <Td>
+                  {title}
+                </Td>
+                <Td>
+                  {sessionType}
+                </Td>
+                <Td>
+                  <Badge
+                    colorScheme={status === 'pending_confirmation' ? 'yellow' : 'red'}
+                  >
+                    {status === 'pending_confirmation' ? 'Awaiting Confirmation' : 'Rejected'}
+                  </Badge>
+                </Td>
+                <Td>
+                  {reason && <Icon name="info" />}
+
+                </Td>
+              </Tr>
+            )
+          })}
         </Tbody>
       </Table>
     </TableContainer>

--- a/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/PendingSessionsTable.tsx
@@ -1,5 +1,6 @@
 import {
-  Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr, Badge, Text, VStack, Button, HStack,
+  Flex, Table, TableContainer, Tbody, Td,
+  Th, Thead, Tr, Badge, Text, VStack, Button, HStack,
 } from '@chakra-ui/react'
 import { useAppSelector } from '../../../hooks'
 import { getAuth } from '../../../app/redux/selectors'
@@ -30,8 +31,8 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
           <Tr>
             <Th>Date & Time</Th>
             <Th>Title</Th>
-            <Th> Type </Th>
-            <Th> Status </Th>
+            <Th>Type</Th>
+            <Th>Status</Th>
             <Th> <Flex justifyContent="center">Reason </Flex></Th>
           </Tr>
         </Thead>
@@ -49,15 +50,15 @@ function PendingSessionsTableMentor(props: PendingSessionsTableProps) {
               <Tr>
                 <Td>
                   <VStack alignItems="start">
-                    <Text color="primary.800"> {date}</Text>
+                    <Text color="primary.800" fontSize="sm"> {date}</Text>
                     <Text> {time}</Text>
                   </VStack>
                 </Td>
                 <Td>
                   {title}
                 </Td>
-                <Td>
-                  {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
+                <Td textTransform="capitalize">
+                  {sessionType}
                 </Td>
                 <Td>
                   <Badge
@@ -87,8 +88,8 @@ function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
           <Tr>
             <Th>Date & Time</Th>
             <Th>Title</Th>
-            <Th> Type </Th>
-            <Th><Flex display="flex" justifyContent="start">Status</Flex>  </Th>
+            <Th>Type</Th>
+            <Th><Flex justifyContent="start">Status</Flex></Th>
           </Tr>
         </Thead>
         <Tbody>
@@ -105,37 +106,35 @@ function PendingSessionsTableMentee(props: PendingSessionsTableProps) {
               <Tr>
                 <Td>
                   <VStack alignItems="start">
-                    <Text color="primary.800"> {date}</Text>
-                    <Text> {time}</Text>
+                    <Text color="primary.800" fontSize="sm">{date}</Text>
+                    <Text>{time}</Text>
                   </VStack>
                 </Td>
                 <Td>
                   {title}
                 </Td>
-                <Td>
-                  {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
+                <Td textTransform="capitalize">
+                  {sessionType}
                 </Td>
                 <Td>
                   {status === 'Pending' && (
-                    <HStack display="flex" justifyContent="start">
+                    <HStack justifyContent="start">
                       <Button colorScheme="red" size="sm">
                         <HStack>
                           <Icon name="done" color="white" />
-                          <Text> Accept</Text>
+                          <Text>Accept</Text>
                         </HStack>
                       </Button>
                       <Button colorScheme="red" variant="outline" size="sm">
                         <HStack>
                           <Icon name="close" color="primary.700" />
-                          <Text> Decline</Text>
+                          <Text>Decline</Text>
                         </HStack>
                       </Button>
                     </HStack>
                   )}
                   {status === 'Rejected' && (
-                    <Badge
-                      colorScheme="yellow"
-                    >
+                    <Badge colorScheme="yellow">
                       Awaiting Confirmation
                     </Badge>
                   )}

--- a/src/features/Sessions/SessionsTable/UpcomingAndPastSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/UpcomingAndPastSessionsTable.tsx
@@ -1,8 +1,14 @@
 import {
   Button, Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr,
 } from '@chakra-ui/react'
+import { SessionResponse } from '../../../app/services/session/types'
 
-function UpcomingAndPastSessionsTable() {
+interface UpcomingandPastSessionProps {
+  data: SessionResponse
+}
+
+function UpcomingAndPastSessionsTable(props: UpcomingandPastSessionProps) {
+  const { data } = props
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">

--- a/src/features/Sessions/SessionsTable/UpcomingAndPastSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/UpcomingAndPastSessionsTable.tsx
@@ -1,5 +1,5 @@
 import {
-  Button, Flex, Table, TableContainer, Tbody, Td, Th, Thead, Tr,
+  Flex, Button, Table, TableContainer, Tbody, Td, Th, Thead, Tr, VStack, Text,
 } from '@chakra-ui/react'
 import { SessionResponse } from '../../../app/services/session/types'
 
@@ -21,18 +21,37 @@ function UpcomingAndPastSessionsTable(props: UpcomingandPastSessionProps) {
           </Tr>
         </Thead>
         <Tbody>
-          <Tr>
-            <Td>
-              <Flex gap="2" align="center" />
-            </Td>
-            <Td />
-            <Td />
-            <Td>
-              <Flex justify="end">
-                <Button>View Details</Button>
-              </Flex>
-            </Td>
-          </Tr>
+          {data.map((session) => {
+            const {
+              fromDateTime, title, sessionType,
+            } = session
+
+            const dateObject = new Date(fromDateTime)
+            const date = dateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+            const time = dateObject.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+
+            return (
+              <Tr>
+                <Td>
+                  <VStack alignItems="start">
+                    <Text color="primary.800"> {date}</Text>
+                    <Text> {time}</Text>
+                  </VStack>
+                </Td>
+                <Td>
+                  {title}
+                </Td>
+                <Td>
+                  {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
+                </Td>
+                <Td>
+                  <Flex justify="end">
+                    <Button>View Details</Button>
+                  </Flex>
+                </Td>
+              </Tr>
+            )
+          })}
         </Tbody>
       </Table>
     </TableContainer>

--- a/src/features/Sessions/SessionsTable/UpcomingAndPastSessionsTable.tsx
+++ b/src/features/Sessions/SessionsTable/UpcomingAndPastSessionsTable.tsx
@@ -34,15 +34,15 @@ function UpcomingAndPastSessionsTable(props: UpcomingandPastSessionProps) {
               <Tr>
                 <Td>
                   <VStack alignItems="start">
-                    <Text color="primary.800"> {date}</Text>
+                    <Text color="primary.800" fontSize="sm"> {date}</Text>
                     <Text> {time}</Text>
                   </VStack>
                 </Td>
                 <Td>
                   {title}
                 </Td>
-                <Td>
-                  {sessionType.charAt(0).toUpperCase() + sessionType.slice(1)}
+                <Td textTransform="capitalize">
+                  {sessionType}
                 </Td>
                 <Td>
                   <Flex justify="end">


### PR DESCRIPTION
<!-- Use GitHub’s “Reviewers” UI to request reviews. -->
<!-- For code-owner approval: Specify a 'full' or 'narrow' review. -->

## Context
Completed desktop and mobile view for allowing mentors and mentees to view all sessions assigned to them

JIRA ticket: https://teamhalpert.atlassian.net/jira/software/projects/TH/boards/1/backlog?selectedIssue=TH-64
https://teamhalpert.atlassian.net/jira/software/projects/TH/boards/1/backlog?selectedIssue=TH-18

## Approach

- Session component will pass filter and pass down the respective sessions to upcoming/past/pending sessions
- Upcoming and Past Sessions will be sharing the same component
- Pending Sessions has its own component with different views for Mentors and Mentees 

### Before & After

<!-- Changes before & after the PR (Optional) -->

## Checklist

- [ ] My branch is up-to-date with the `main` branch
- [ ] Unit and Integration test written
- [ ] Acceptance Criteria considered and implemented
- [ ] Automated tests are passing

## Test Instruction

<!-- How to perform a test for the changes in this PR (Just the steps to produce the good path) -->

## Risks

Medium
