### PR TITLE
Th 28/31/54/view session and quarterly feedback for mentors and mentee

### DIFF
--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -14,6 +14,7 @@ import MenteeMilestones from '../features/MentoringJourneys/MentoringJourneyDeta
 import { Sessions } from '../features/Sessions'
 import { SessionDetails } from '../features/Sessions/SessionDetails'
 import SessionFeedback from '../features/Feedback/Feedback'
+import MenteeFeedback from '../features/Feedback/MenteeFeedback'
 
 function AppLayout() {
   const { role } = useAppSelector(getAuth)
@@ -50,7 +51,7 @@ function AppLayout() {
               <Route path={paths.Milestones} element={<MenteeMilestones />} />
               <Route path={paths.Sessions.ViewAll} element={<Sessions />} />
               <Route path={paths.Sessions.Details.fullPath} element={<SessionDetails />} />
-              <Route path={paths.Feedback} element={<SessionFeedback />} />
+              <Route path={paths.Feedback} element={<MenteeFeedback />} />
             </Routes>
           )}
         </Box>

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -13,6 +13,7 @@ import { AssignedMentees } from '../features/AssignedMentees'
 import MenteeMilestones from '../features/MentoringJourneys/MentoringJourneyDetails/Milestones/MenteeMilestones'
 import { Sessions } from '../features/Sessions'
 import { SessionDetails } from '../features/Sessions/SessionDetails'
+import SessionFeedback from '../features/Feedback/Feedback'
 
 function AppLayout() {
   const { role } = useAppSelector(getAuth)
@@ -49,6 +50,7 @@ function AppLayout() {
               <Route path={paths.Milestones} element={<MenteeMilestones />} />
               <Route path={paths.Sessions.ViewAll} element={<Sessions />} />
               <Route path={paths.Sessions.Details.fullPath} element={<SessionDetails />} />
+              <Route path={paths.Feedback} element={<SessionFeedback />} />
             </Routes>
           )}
         </Box>

--- a/src/app/AppLayout.tsx
+++ b/src/app/AppLayout.tsx
@@ -13,7 +13,6 @@ import { AssignedMentees } from '../features/AssignedMentees'
 import MenteeMilestones from '../features/MentoringJourneys/MentoringJourneyDetails/Milestones/MenteeMilestones'
 import { Sessions } from '../features/Sessions'
 import { SessionDetails } from '../features/Sessions/SessionDetails'
-import SessionFeedback from '../features/Feedback/Feedback'
 import MenteeFeedback from '../features/Feedback/MenteeFeedback'
 
 function AppLayout() {

--- a/src/app/services/feedback/apiFeedbackSlice.ts
+++ b/src/app/services/feedback/apiFeedbackSlice.ts
@@ -1,6 +1,9 @@
 import { apiSlice } from '../apiSlice'
 import { defaultOnQueryStarted as onQueryStarted } from '../utils'
-import { MenteeQuarterlyFeedbackResponse, MenteeSessionFeedbackResponse, MentorQuarterlyFeedbackResponse, MentorSessionFeedbackResponse } from './type'
+import {
+  MenteeQuarterlyFeedbackResponse, MenteeSessionFeedbackResponse,
+  MentorQuarterlyFeedbackResponse, MentorSessionFeedbackResponse,
+} from './type'
 
 const apiFeedbackSlice = apiSlice.injectEndpoints({
   endpoints: (build) => ({

--- a/src/app/services/feedback/apiFeedbackSlice.ts
+++ b/src/app/services/feedback/apiFeedbackSlice.ts
@@ -1,10 +1,31 @@
 import { apiSlice } from '../apiSlice'
 import { defaultOnQueryStarted as onQueryStarted } from '../utils'
-import { MentorSessionFeedbackResponse } from './type'
+import { MentorQuarterlyFeedbackResponse, MentorSessionFeedbackResponse } from './type'
 
 const apiFeedbackSlice = apiSlice.injectEndpoints({
   endpoints: (build) => ({
-    getMentorSessionFeedback: build.query<MentorSessionFeedbackResponse, null>({
+    getMentorSessionFeedback: build.query<MentorSessionFeedbackResponse, string | number>({
+      query: (mentoringJourneyId) => ({
+        url: `session/mentor/mentoring-journey/${mentoringJourneyId}`,
+        method: 'GET',
+      }),
+      onQueryStarted,
+    }),
+    getMentorQuarterlyFeedback: build.query<MentorQuarterlyFeedbackResponse, string | number>({
+      query: (mentoringJourneyId) => ({
+        url: `mentor/mentoring-journey/feedbacks/quarterly/${mentoringJourneyId}`,
+        method: 'GET',
+      }),
+      onQueryStarted,
+    }),
+    getMenteeSessionFeedback: build.query<MentorSessionFeedbackResponse, null>({
+      query: () => ({
+        url: '',
+        method: 'GET',
+      }),
+      onQueryStarted,
+    }),
+    getMenteeQuarterlyFeedback: build.query<MentorSessionFeedbackResponse, null>({
       query: () => ({
         url: '',
         method: 'GET',
@@ -17,4 +38,5 @@ const apiFeedbackSlice = apiSlice.injectEndpoints({
 
 export const {
   useGetMentorSessionFeedbackQuery,
+  useGetMentorQuarterlyFeedbackQuery,
 } = apiFeedbackSlice

--- a/src/app/services/feedback/apiFeedbackSlice.ts
+++ b/src/app/services/feedback/apiFeedbackSlice.ts
@@ -1,6 +1,6 @@
 import { apiSlice } from '../apiSlice'
 import { defaultOnQueryStarted as onQueryStarted } from '../utils'
-import { MentorQuarterlyFeedbackResponse, MentorSessionFeedbackResponse } from './type'
+import { MenteeQuarterlyFeedbackResponse, MenteeSessionFeedbackResponse, MentorQuarterlyFeedbackResponse, MentorSessionFeedbackResponse } from './type'
 
 const apiFeedbackSlice = apiSlice.injectEndpoints({
   endpoints: (build) => ({
@@ -18,16 +18,16 @@ const apiFeedbackSlice = apiSlice.injectEndpoints({
       }),
       onQueryStarted,
     }),
-    getMenteeSessionFeedback: build.query<MentorSessionFeedbackResponse, null>({
+    getMenteeSessionFeedback: build.query<MenteeSessionFeedbackResponse, null>({
       query: () => ({
-        url: '',
+        url: 'session/mentee/feedback',
         method: 'GET',
       }),
       onQueryStarted,
     }),
-    getMenteeQuarterlyFeedback: build.query<MentorSessionFeedbackResponse, null>({
+    getMenteeQuarterlyFeedback: build.query<MenteeQuarterlyFeedbackResponse, null>({
       query: () => ({
-        url: '',
+        url: 'mentee/mentoring-journey/feedbacks/quarterly',
         method: 'GET',
       }),
       onQueryStarted,
@@ -39,4 +39,6 @@ const apiFeedbackSlice = apiSlice.injectEndpoints({
 export const {
   useGetMentorSessionFeedbackQuery,
   useGetMentorQuarterlyFeedbackQuery,
+  useGetMenteeSessionFeedbackQuery,
+  useGetMenteeQuarterlyFeedbackQuery,
 } = apiFeedbackSlice

--- a/src/app/services/feedback/apiFeedbackSlice.ts
+++ b/src/app/services/feedback/apiFeedbackSlice.ts
@@ -1,0 +1,20 @@
+import { apiSlice } from '../apiSlice'
+import { defaultOnQueryStarted as onQueryStarted } from '../utils'
+import { MentorSessionFeedbackResponse } from './type'
+
+const apiFeedbackSlice = apiSlice.injectEndpoints({
+  endpoints: (build) => ({
+    getMentorSessionFeedback: build.query<MentorSessionFeedbackResponse, null>({
+      query: () => ({
+        url: '',
+        method: 'GET',
+      }),
+      onQueryStarted,
+    }),
+  }),
+  overrideExisting: false,
+})
+
+export const {
+  useGetMentorSessionFeedbackQuery,
+} = apiFeedbackSlice

--- a/src/app/services/feedback/type.ts
+++ b/src/app/services/feedback/type.ts
@@ -1,0 +1,3 @@
+export interface MentorSessionFeedbackResponse {
+    
+}

--- a/src/app/services/feedback/type.ts
+++ b/src/app/services/feedback/type.ts
@@ -1,3 +1,29 @@
+export interface SessionFeedback {
+  sessionFeedbackId: string
+  sessionId: string
+  fromDateTime: string
+  toDateTime: string
+  title: string
+  sessionType: string
+  status: string
+}
+
+export interface QuarterlyFeedback{
+  quarterlyFeedbackId: string
+  feedbackAnswers: string[]
+  date: string
+  status: string
+  mentoringJourneyId: string
+}
+
 export interface MentorSessionFeedbackResponse {
-    
+  mentorSessionFeedbacks: SessionFeedback[]
+}
+
+export interface MenteeSessionFeedbackResponse {
+  menteeSessionFeedbacks: SessionFeedback[]
+}
+
+export interface MentorQuarterlyFeedbackResponse {
+  mentorQuarterlyFeedbacks: QuarterlyFeedback[]
 }

--- a/src/app/services/feedback/type.ts
+++ b/src/app/services/feedback/type.ts
@@ -27,3 +27,7 @@ export interface MenteeSessionFeedbackResponse {
 export interface MentorQuarterlyFeedbackResponse {
   mentorQuarterlyFeedbacks: QuarterlyFeedback[]
 }
+
+export interface MenteeQuarterlyFeedbackResponse {
+  menteeQuarterlyFeedbacks: QuarterlyFeedback[]
+}

--- a/src/features/Feedback/Feedback.tsx
+++ b/src/features/Feedback/Feedback.tsx
@@ -1,0 +1,38 @@
+import {
+  Box,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+} from '@chakra-ui/react'
+import Container from '../../components/Container'
+import SessionFeedback from './SessionFeedback'
+import QuarterlyFeedback from './QuarterlyFeedback'
+
+function Feedback() {
+  return (
+    <Container minHeight="calc(100vh - 32px)">
+      <Box paddingY="5">
+        <Text fontSize="2xl" fontWeight="600"> Feedback </Text>
+        <Text color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
+      </Box>
+      <Tabs mt="5" colorScheme="red">
+        <TabList gap="10">
+          <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Session Feedback</Tab>
+          <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Quarterly Feedback</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel px="0">
+            <SessionFeedback />
+          </TabPanel>
+          <TabPanel px="0">
+            <QuarterlyFeedback />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Container>
+  )
+}
+export default Feedback

--- a/src/features/Feedback/Feedback.tsx
+++ b/src/features/Feedback/Feedback.tsx
@@ -1,17 +1,22 @@
 import {
-  Box,
   Tab,
   TabList,
   TabPanel,
   TabPanels,
   Tabs,
-  Text,
 } from '@chakra-ui/react'
-import Container from '../../components/Container'
 import SessionFeedback from './SessionFeedback'
 import QuarterlyFeedback from './QuarterlyFeedback'
+import { QuarterlyFeedback as QuarterlyFeedbackType, SessionFeedback as SessionFeedbackType } from '../../app/services/feedback/type'
 
-function Feedback() {
+interface FeedbackProps {
+  sessionFeedbackData: SessionFeedbackType[] | undefined
+  quarterlyFeedbackData: QuarterlyFeedbackType[] | undefined
+}
+
+function Feedback(props: FeedbackProps) {
+  const { sessionFeedbackData, quarterlyFeedbackData } = props
+
   return (
     <Tabs mt="5" colorScheme="red" variant="solid-rounded">
       <TabList gap="10">
@@ -20,10 +25,10 @@ function Feedback() {
       </TabList>
       <TabPanels>
         <TabPanel px="0">
-          <SessionFeedback />
+          <SessionFeedback data={sessionFeedbackData} />
         </TabPanel>
         <TabPanel px="0">
-          <QuarterlyFeedback />
+          <QuarterlyFeedback data={quarterlyFeedbackData} />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/src/features/Feedback/Feedback.tsx
+++ b/src/features/Feedback/Feedback.tsx
@@ -13,26 +13,20 @@ import QuarterlyFeedback from './QuarterlyFeedback'
 
 function Feedback() {
   return (
-    <Container minHeight="calc(100vh - 32px)">
-      <Box paddingY="5">
-        <Text fontSize="2xl" fontWeight="600"> Feedback </Text>
-        <Text color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
-      </Box>
-      <Tabs mt="5" colorScheme="red">
-        <TabList gap="10">
-          <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Session Feedback</Tab>
-          <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Quarterly Feedback</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel px="0">
-            <SessionFeedback />
-          </TabPanel>
-          <TabPanel px="0">
-            <QuarterlyFeedback />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Container>
+    <Tabs mt="5" colorScheme="red" variant="solid-rounded">
+      <TabList gap="10">
+        <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Session Feedback</Tab>
+        <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Quarterly Feedback</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel px="0">
+          <SessionFeedback />
+        </TabPanel>
+        <TabPanel px="0">
+          <QuarterlyFeedback />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
   )
 }
 export default Feedback

--- a/src/features/Feedback/Feedback.tsx
+++ b/src/features/Feedback/Feedback.tsx
@@ -20,8 +20,8 @@ function Feedback(props: FeedbackProps) {
   return (
     <Tabs mt="5" colorScheme="red" variant="solid-rounded">
       <TabList gap="10">
-        <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Session Feedback</Tab>
-        <Tab py="1" px={['1', '2', '4']} fontSize={['xs', 'sm', 'md']}>Quarterly Feedback</Tab>
+        <Tab py="1" px={[2, 4]} fontSize={['xs', 'sm', 'md']}>Session Feedback</Tab>
+        <Tab py="1" px={[2, 4]} fontSize={['xs', 'sm', 'md']}>Quarterly Feedback</Tab>
       </TabList>
       <TabPanels>
         <TabPanel px="0">

--- a/src/features/Feedback/MenteeFeedback.tsx
+++ b/src/features/Feedback/MenteeFeedback.tsx
@@ -1,15 +1,18 @@
 import { Box, Text } from '@chakra-ui/react'
 import Feedback from './Feedback'
 import { Container } from '../../components'
+import { useGetMenteeQuarterlyFeedbackQuery, useGetMenteeSessionFeedbackQuery } from '../../app/services/feedback/apiFeedbackSlice'
 
 function MenteeFeedback() {
+  const { data: menteeSessionFeedbackData } = useGetMenteeSessionFeedbackQuery(null)
+  const { data: menteeQuarterlyFeedbackData } = useGetMenteeQuarterlyFeedbackQuery(null)
   return (
     <Container minHeight="calc(100vh - 32px)">
       <Box paddingY="5">
         <Text fontSize="2xl" fontWeight="600"> Feedback </Text>
         <Text color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
       </Box>
-      <Feedback userRole="Mentee" />
+      <Feedback sessionFeedbackData={menteeSessionFeedbackData?.menteeSessionFeedbacks} quarterlyFeedbackData={menteeQuarterlyFeedbackData?.menteeQuarterlyFeedbacks} />
     </Container>
   )
 }

--- a/src/features/Feedback/MenteeFeedback.tsx
+++ b/src/features/Feedback/MenteeFeedback.tsx
@@ -9,7 +9,7 @@ function MenteeFeedback() {
         <Text fontSize="2xl" fontWeight="600"> Feedback </Text>
         <Text color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
       </Box>
-      <Feedback />
+      <Feedback userRole="Mentee" />
     </Container>
   )
 }

--- a/src/features/Feedback/MenteeFeedback.tsx
+++ b/src/features/Feedback/MenteeFeedback.tsx
@@ -1,0 +1,16 @@
+import { Box, Text } from '@chakra-ui/react'
+import Feedback from './Feedback'
+import { Container } from '../../components'
+
+function MenteeFeedback() {
+  return (
+    <Container minHeight="calc(100vh - 32px)">
+      <Box paddingY="5">
+        <Text fontSize="2xl" fontWeight="600"> Feedback </Text>
+        <Text color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
+      </Box>
+      <Feedback />
+    </Container>
+  )
+}
+export default MenteeFeedback

--- a/src/features/Feedback/MentorFeedback.tsx
+++ b/src/features/Feedback/MentorFeedback.tsx
@@ -1,0 +1,12 @@
+import { Box, Text } from '@chakra-ui/react'
+import Feedback from './Feedback'
+
+function MentorFeedback() {
+  return (
+    <Box>
+      <Text marginBottom="7" marginTop="2" color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
+      <Feedback />
+    </Box>
+  )
+}
+export default MentorFeedback

--- a/src/features/Feedback/MentorFeedback.tsx
+++ b/src/features/Feedback/MentorFeedback.tsx
@@ -1,11 +1,16 @@
 import { Box, Text } from '@chakra-ui/react'
+import { useParams } from 'react-router-dom'
 import Feedback from './Feedback'
+import { useGetMentorQuarterlyFeedbackQuery, useGetMentorSessionFeedbackQuery } from '../../app/services/feedback/apiFeedbackSlice'
 
 function MentorFeedback() {
+  const { mentoringJourneyId } = useParams()
+  const { data: mentorSessionFeedbackData } = useGetMentorSessionFeedbackQuery(mentoringJourneyId!)
+  const { data: mentorQuarterlyFeedbackData } = useGetMentorQuarterlyFeedbackQuery(mentoringJourneyId!)
   return (
     <Box>
       <Text marginBottom="7" marginTop="2" color="secondary.500">Manage your feedback for each session and quarter of each milestone</Text>
-      <Feedback />
+      <Feedback sessionFeedbackData={mentorSessionFeedbackData?.mentorSessionFeedbacks} quarterlyFeedbackData={mentorQuarterlyFeedbackData?.mentorQuarterlyFeedbacks} />
     </Box>
   )
 }

--- a/src/features/Feedback/QuarterlyFeedback.tsx
+++ b/src/features/Feedback/QuarterlyFeedback.tsx
@@ -6,10 +6,12 @@ import {
 import { QuarterlyFeedback as QuarterlyFeedbackType } from '../../app/services/feedback/type'
 import { Link } from '../../components'
 import paths from '../../paths'
+import { getStatus } from './utils'
 
 interface QuarterlyFeedbackProps {
   data: QuarterlyFeedbackType[] | undefined
 }
+
 function QuarterlyFeedback(props: QuarterlyFeedbackProps) {
   const { data } = props
   return (
@@ -26,9 +28,7 @@ function QuarterlyFeedback(props: QuarterlyFeedbackProps) {
         </Thead>
         <Tbody>
           {data?.map((feedback, index) => {
-            const {
-              date, status,
-            } = feedback
+            const { date, status } = feedback
 
             const quarterDateObject = new Date(date)
             const todayDateObject = new Date()
@@ -36,16 +36,9 @@ function QuarterlyFeedback(props: QuarterlyFeedbackProps) {
             const quarterDate = quarterDateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
 
             const dateDifference = Math.round((quarterDateObject.getTime() - todayDateObject.getTime()) / (1000 * 60 * 60 * 24))
+            const formattedStatus = getStatus(status, dateDifference)
+            const isUnavailable = formattedStatus === 'Unavailable'
 
-            function getStatus(status: string) {
-              if (status === 'Not Completed' && dateDifference <= 0) {
-                return 'Pending'
-              }
-              if (status === 'Not Completed' && dateDifference > 0) {
-                return 'Unavailable'
-              }
-              return 'Complete'
-            }
             return (
               <Tr>
                 <Td>
@@ -55,7 +48,7 @@ function QuarterlyFeedback(props: QuarterlyFeedbackProps) {
                   {quarterDate}
                 </Td>
                 <Td textTransform="capitalize">
-                  {getStatus(status)}
+                  {formattedStatus}
                 </Td>
                 <Td>
                   {dateDifference} days
@@ -65,7 +58,7 @@ function QuarterlyFeedback(props: QuarterlyFeedbackProps) {
                     {/* TODO: Khye chun add integration  */}
                     {status === 'Not Completed' && (
                       <Link to={paths.Introduction}>
-                        <Button size="sm" colorScheme="red" isDisabled={getStatus(status) === 'Unavailable'}>Submit Feedback</Button>
+                        <Button size="sm" colorScheme="red" isDisabled={isUnavailable}>Submit Feedback</Button>
                       </Link>
                     )}
                     {/* TODO: Khye chun add integration  */}

--- a/src/features/Feedback/QuarterlyFeedback.tsx
+++ b/src/features/Feedback/QuarterlyFeedback.tsx
@@ -1,8 +1,17 @@
 import {
-  Table, TableContainer, Tbody, Th, Thead, Tr,
+  Button,
+  Flex,
+  Table, TableContainer, Tbody, Td, Th, Thead, Tr,
 } from '@chakra-ui/react'
+import { QuarterlyFeedback as QuarterlyFeedbackType } from '../../app/services/feedback/type'
+import { Link } from '../../components'
+import paths from '../../paths'
 
-function QuarterlyFeedback() {
+interface QuarterlyFeedbackProps {
+  data: QuarterlyFeedbackType[] | undefined
+}
+function QuarterlyFeedback(props: QuarterlyFeedbackProps) {
+  const { data } = props
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">
@@ -15,7 +24,62 @@ function QuarterlyFeedback() {
             <Th />
           </Tr>
         </Thead>
-        <Tbody />
+        <Tbody>
+          {data?.map((feedback, index) => {
+            const {
+              date, status,
+            } = feedback
+
+            const quarterDateObject = new Date(date)
+            const todayDateObject = new Date()
+
+            const quarterDate = quarterDateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+
+            const dateDifference = Math.round((quarterDateObject.getTime() - todayDateObject.getTime()) / (1000 * 60 * 60 * 24))
+
+            function getStatus(status: string) {
+              if (status === 'Not Completed' && dateDifference <= 0) {
+                return 'Pending'
+              }
+              if (status === 'Not Completed' && dateDifference > 0) {
+                return 'Unavailable'
+              }
+              return 'Complete'
+            }
+            return (
+              <Tr>
+                <Td>
+                  Quarter {index + 1}
+                </Td>
+                <Td>
+                  {quarterDate}
+                </Td>
+                <Td textTransform="capitalize">
+                  {getStatus(status)}
+                </Td>
+                <Td>
+                  {dateDifference} days
+                </Td>
+                <Td>
+                  <Flex justify="end" gap="5">
+                    {/* TODO: Khye chun add integration  */}
+                    {status === 'Not Completed' && (
+                      <Link to={paths.Introduction}>
+                        <Button size="sm" colorScheme="red" isDisabled={getStatus(status) === 'Unavailable'}>Submit Feedback</Button>
+                      </Link>
+                    )}
+                    {/* TODO: Khye chun add integration  */}
+                    {status === 'Completed' && (
+                      <Link to={paths.Introduction}>
+                        <Button size="sm" colorScheme="red">View Feedback</Button>
+                      </Link>
+                    )}
+                  </Flex>
+                </Td>
+              </Tr>
+            )
+          })}
+        </Tbody>
       </Table>
     </TableContainer>
   )

--- a/src/features/Feedback/QuarterlyFeedback.tsx
+++ b/src/features/Feedback/QuarterlyFeedback.tsx
@@ -1,0 +1,23 @@
+import {
+  Table, TableContainer, Tbody, Th, Thead, Tr,
+} from '@chakra-ui/react'
+
+function QuarterlyFeedback() {
+  return (
+    <TableContainer whiteSpace="unset" width="100%">
+      <Table variant="simple">
+        <Thead backgroundColor="gray.100">
+          <Tr>
+            <Th>Quarter</Th>
+            <Th>Date</Th>
+            <Th>Status</Th>
+            <Th>Available In</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody />
+      </Table>
+    </TableContainer>
+  )
+}
+export default QuarterlyFeedback

--- a/src/features/Feedback/SessionFeedback.tsx
+++ b/src/features/Feedback/SessionFeedback.tsx
@@ -1,0 +1,22 @@
+import {
+  Table, TableContainer, Tbody, Th, Thead, Tr,
+} from '@chakra-ui/react'
+
+function SessionFeedback() {
+  return (
+    <TableContainer whiteSpace="unset" width="100%">
+      <Table variant="simple">
+        <Thead backgroundColor="gray.100">
+          <Tr>
+            <Th>Date & Time</Th>
+            <Th>Title</Th>
+            <Th>Type</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody />
+      </Table>
+    </TableContainer>
+  )
+}
+export default SessionFeedback

--- a/src/features/Feedback/SessionFeedback.tsx
+++ b/src/features/Feedback/SessionFeedback.tsx
@@ -1,8 +1,18 @@
 import {
-  Table, TableContainer, Tbody, Th, Thead, Tr,
+  Button,
+  Flex,
+  Table, TableContainer, Tbody, Td, Th, Thead, Tr, VStack, Text,
 } from '@chakra-ui/react'
+import { SessionFeedback as SessionFeedbackType } from '../../app/services/feedback/type'
+import paths from '../../paths'
+import { Link } from '../../components'
 
-function SessionFeedback() {
+interface SessionFeedbackProps {
+  data: SessionFeedbackType[] | undefined
+}
+
+function SessionFeedback(props: SessionFeedbackProps) {
+  const { data } = props
   return (
     <TableContainer whiteSpace="unset" width="100%">
       <Table variant="simple">
@@ -14,7 +24,56 @@ function SessionFeedback() {
             <Th />
           </Tr>
         </Thead>
-        <Tbody />
+        <Tbody>
+          {data?.map((session) => {
+            const {
+              fromDateTime, toDateTime, title, sessionType, sessionId, status,
+            } = session
+
+            const fromDateObject = new Date(fromDateTime)
+            const fromDate = fromDateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+            const fromTime = fromDateObject.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+
+            const toDateObject = new Date(toDateTime)
+            const toDate = toDateObject.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+            const toTime = toDateObject.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+            return (
+              <Tr>
+                <Td>
+                  <VStack alignItems="start">
+                    <Text color="primary.800" fontSize="sm"> {fromDate === toDate ? fromDate : `${fromDate} - ${toDate}`}</Text>
+                    <Text> {`${fromTime} to ${toTime}`}</Text>
+                  </VStack>
+                </Td>
+                <Td>
+                  {title}
+                </Td>
+                <Td textTransform="capitalize">
+                  {sessionType}
+                </Td>
+                <Td>
+                  <Flex justify="end" gap="5">
+                    {/* TODO: Khye chun add integration  */}
+                    {status === 'Not Completed' && (
+                      <Link to={`${paths.Sessions.Details.subPath}/${sessionId}`}>
+                        <Button size="sm" colorScheme="red">Rate Session</Button>
+                      </Link>
+                    )}
+                    {/* TODO: Khye chun add integration  */}
+                    {status === 'Completed' && (
+                      <Link to={`${paths.Sessions.Details.subPath}/${sessionId}`}>
+                        <Button size="sm" colorScheme="red">View Feedback</Button>
+                      </Link>
+                    )}
+                    <Link to={`${paths.Sessions.Details.subPath}/${sessionId}`}>
+                      <Button size="sm" colorScheme="red" variant="outline">Session Details</Button>
+                    </Link>
+                  </Flex>
+                </Td>
+              </Tr>
+            )
+          })}
+        </Tbody>
       </Table>
     </TableContainer>
   )

--- a/src/features/Feedback/SessionFeedback.tsx
+++ b/src/features/Feedback/SessionFeedback.tsx
@@ -52,7 +52,7 @@ function SessionFeedback(props: SessionFeedbackProps) {
                   {sessionType}
                 </Td>
                 <Td>
-                  <Flex justify="end" gap="5">
+                  <Flex justify="end" gap="2">
                     {/* TODO: Khye chun add integration  */}
                     {status === 'Not Completed' && (
                       <Link to={`${paths.Sessions.Details.subPath}/${sessionId}`}>

--- a/src/features/Feedback/utils.ts
+++ b/src/features/Feedback/utils.ts
@@ -1,0 +1,9 @@
+export function getStatus(status: string, dateDifference: number) {
+  if (status === 'Not Completed' && dateDifference <= 0) {
+    return 'Pending'
+  }
+  if (status === 'Not Completed' && dateDifference > 0) {
+    return 'Unavailable'
+  }
+  return 'Complete'
+}

--- a/src/features/MentoringJourneys/MentoringJourneyDetails/MentoringJourneyDetails.tsx
+++ b/src/features/MentoringJourneys/MentoringJourneyDetails/MentoringJourneyDetails.tsx
@@ -7,6 +7,8 @@ import { BackButton, Container } from '../../../components'
 import paths from '../../../paths'
 import Overview from './Overview'
 import MentorMilestones from './Milestones/MentorMilestones'
+import Feedback from '../../Feedback/Feedback'
+import MentorFeedback from '../../Feedback/MentorFeedback'
 
 function MentoringJourneyDetails() {
   return (
@@ -29,7 +31,7 @@ function MentoringJourneyDetails() {
             </Box>
           </TabPanel>
           <TabPanel px="0">
-            Feedback
+            <MentorFeedback />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/features/MentoringJourneys/MentoringJourneyDetails/MentoringJourneyDetails.tsx
+++ b/src/features/MentoringJourneys/MentoringJourneyDetails/MentoringJourneyDetails.tsx
@@ -7,7 +7,6 @@ import { BackButton, Container } from '../../../components'
 import paths from '../../../paths'
 import Overview from './Overview'
 import MentorMilestones from './Milestones/MentorMilestones'
-import Feedback from '../../Feedback/Feedback'
 import MentorFeedback from '../../Feedback/MentorFeedback'
 
 function MentoringJourneyDetails() {

--- a/src/features/Sessions/SessionDetails/DeleteSessionModal.tsx
+++ b/src/features/Sessions/SessionDetails/DeleteSessionModal.tsx
@@ -42,7 +42,7 @@ function DeleteSessionModal(props: DeleteSessionModalProps) {
   return (
     <Modal isOpen={isModalOpen} onClose={onModalClose} size="2xl" isCentered>
       <ModalOverlay />
-      <ModalContent p="4" m="4" maxHeight="70vh">
+      <ModalContent p="4" m="4" maxHeight="90vh" overflowY="auto">
         <ModalHeader> Delete Mentoring Session</ModalHeader>
         <ModalCloseButton />
         <ModalBody>

--- a/src/features/Sessions/SessionDetails/SessionDetails.tsx
+++ b/src/features/Sessions/SessionDetails/SessionDetails.tsx
@@ -1,10 +1,10 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import {
-  Box, Divider, Text, Flex, HStack, Button, useDisclosure, Link,
+  Box, Divider, Text, Flex, HStack, Button, useDisclosure,
 } from '@chakra-ui/react'
 import { useEffect } from 'react'
 import {
-  BackButton, Container, Icon, ProfileIcon,
+  BackButton, Container, Icon, Link, ProfileIcon,
 } from '../../../components'
 import paths from '../../../paths'
 import { useLazyGetSessionDetailsMenteeQuery, useLazyGetSessionDetailsMentorQuery } from '../../../app/services/session/apiSessionSlice'
@@ -12,6 +12,7 @@ import { useAppSelector } from '../../../hooks'
 import { getAuth } from '../../../app/redux/selectors'
 import SessionFormModal from '../SessionFormModal/SessionFormModal'
 import DeleteSessionModal from './DeleteSessionModal'
+import { ensureProtocol } from '../../../utils'
 
 function SessionDetails() {
   const { sessionId } = useParams()
@@ -53,15 +54,6 @@ function SessionDetails() {
 
   const isPast = endDateObject <= todayDate
 
-  function ensureProtocol(url: string | undefined) {
-    if (!url) {
-      return ''
-    }
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
-      return `https://${url}`
-    }
-    return url
-  }
   const handleViewMentee = () => {
     navigate(`${paths.AssignedMentees}/${menteeId}`)
   }
@@ -104,7 +96,7 @@ function SessionDetails() {
 
       <HStack mt="3">
         <Icon name="location_on" fontSize="25px" />
-        {sessionType === 'online' && <Link color="secondary.500" href={ensureProtocol(location)}>{location}</Link>}
+        {sessionType === 'online' && <Link color="secondary.500" target="_blank" to={ensureProtocol(location)}>{location}</Link>}
         {sessionType === 'physical' && <Text color="secondary.500" isTruncated>{location}</Text>}
       </HStack>
 

--- a/src/features/Sessions/SessionFormModal/SessionFormModal.tsx
+++ b/src/features/Sessions/SessionFormModal/SessionFormModal.tsx
@@ -255,7 +255,7 @@ function SessionFormModal(props: SessionModalProps) {
             </Flex>
             {!!session.location.error && <Text fontSize="xs" color="red.600">{session.sessionType.error}</Text>}
             <Flex alignItems={['start', 'start', 'center']} gap="3" flexDir={['column', 'column', 'row']} width="100%">
-              <Text> {session.location.value === 'online' ? 'Meeting Link:' : 'Address:'}  </Text>
+              <Text> {session.sessionType.value === 'online' ? 'Meeting Link:' : 'Address:'}  </Text>
               <Box flex="1" w="100%">
                 <ControlledTextInput
                   type="text"

--- a/src/features/Sessions/SessionResponseModal/AcceptSessionModal.tsx
+++ b/src/features/Sessions/SessionResponseModal/AcceptSessionModal.tsx
@@ -43,7 +43,7 @@ function AcceptSessionModal(props: AcceptSessionModalProps) {
   return (
     <Modal isOpen={isModalOpen} onClose={onModalClose} size="2xl" isCentered>
       <ModalOverlay />
-      <ModalContent p="4" m="4" maxHeight="70vh">
+      <ModalContent p="4" m="4" maxHeight="90vh" overflowY="auto">
         <ModalHeader> Accept Mentoring Session</ModalHeader>
         <ModalCloseButton />
         <ModalBody>

--- a/src/features/Sessions/SessionResponseModal/DeclineSessionModal.tsx
+++ b/src/features/Sessions/SessionResponseModal/DeclineSessionModal.tsx
@@ -115,7 +115,7 @@ function DeclineSessionModal(props: DeclineSessionModalProps) {
   return (
     <Modal isOpen={isModalOpen} onClose={handleModalClose} size="2xl" isCentered>
       <ModalOverlay />
-      <ModalContent p="4" m="4" maxHeight="70vh">
+      <ModalContent p="4" m="4" maxHeight="90vh" overflowY="auto">
         <ModalHeader> Decline Mentoring Session</ModalHeader>
         <ModalCloseButton />
         <ModalBody>

--- a/src/features/Sessions/SessionResponseModal/UpdateSessionModal.tsx
+++ b/src/features/Sessions/SessionResponseModal/UpdateSessionModal.tsx
@@ -140,7 +140,7 @@ function UpdateSessionModal(props: UpdateSessionModalProps) {
   return (
     <Modal isOpen={isModalOpen} onClose={handleModalClose} size="2xl" isCentered>
       <ModalOverlay />
-      <ModalContent p="4" m="4" maxHeight="70vh">
+      <ModalContent p="4" m="4" maxHeight="90vh" overflowY="auto">
         <ModalHeader> View Decline Reason</ModalHeader>
         <ModalCloseButton />
         <ModalBody>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,3 +33,13 @@ export function clearValues(obj: any) {
 export function formatDate(date: Date) {
   return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
 }
+
+export function ensureProtocol(url: string | undefined) {
+  if (!url) {
+    return ''
+  }
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    return `https://${url}`
+  }
+  return url
+}


### PR DESCRIPTION
<!-- Use GitHub’s “Reviewers” UI to request reviews. -->
<!-- For code-owner approval: Specify a 'full' or 'narrow' review. -->

## Context

- Completed the list view of session and quarterly feedback for mentees
- Completed the list view of session and quarterly feedback for mentors

JIRA ticket: https://teamhalpert.atlassian.net/jira/software/projects/TH/boards/1/backlog?selectedIssue=TH28
JIRA ticket: https://teamhalpert.atlassian.net/jira/software/projects/TH/boards/1/backlog?selectedIssue=TH31
JIRA ticket: https://teamhalpert.atlassian.net/jira/software/projects/TH/boards/1/backlog?selectedIssue=TH54

## Approach

- Created a Parent Component: Session Feedback, which has two child components: Session Feedback and Quarterly Feedback which will dynamically display the respective feedback.
- Created a Wrapper Component: MentorFeedback and MenteeFeedback that wraps SessionFeedback component
- MentorFeedback and MenteeFeedback will call the respective api and pass it down to Session Feedback component and its child components. 

### Before & After

<!-- Changes before & after the PR (Optional) -->

## Checklist

- [ ] My branch is up-to-date with the `main` branch
- [ ] Unit and Integration test written
- [ ] Acceptance Criteria considered and implemented
- [ ] Automated tests are passing

## Test Instruction



## Risks
Low
